### PR TITLE
changing protobuf version and fixing styling errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,16 @@
       <version>0.12.8</version>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.6.1</version>
+      <!--
+         We are being explicit about version here and overriding the
+         spark default of 2.5.0 because KCL appears to have introduced
+         a dependency on protobuf 2.6.1 somewhere between KCL 1.4.0 and 1.6.1.
+       -->
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-cbor</artifactId>
       <version>${fasterxml.jackson.version}</version>
@@ -148,6 +158,7 @@
                   <include>com.amazonaws:aws-java-sdk-core:*</include>
                   <include>com.amazonaws:aws-java-sdk-sts:*</include>
                   <include>com.fasterxml.jackson.dataformat:*:*</include>
+                  <include>com.google.protobuf:*:*</include>
                 </includes>
                 </artifactSet>
                 <relocations>
@@ -163,6 +174,13 @@
                       <shadedPattern>org.apache.spark.sql.kinesis.shaded.amazonaws</shadedPattern>
                       <includes>
                         <include>com.amazonaws.**</include>
+                      </includes>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.protobuf</pattern>
+                      <shadedPattern>org.apache.spark.sql.kinesis.shaded.google.protobuf</shadedPattern>
+                      <includes>
+                        <include>com.google.protobuf.**</include>
                       </includes>
                     </relocation>
                 </relocations>

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSource.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSource.scala
@@ -23,8 +23,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import com.amazonaws.services.kinesis.model.Record
 import org.apache.hadoop.conf.Configuration
-
 import scala.collection.parallel.ForkJoinTaskSupport
+
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql._

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceRDD.scala
@@ -212,7 +212,7 @@ private[kinesis] class KinesisSourceRDD(
       sourceOptions.getOrElse("executor.metadata.path", metadataPath).toString
     }
 
-    
+
     def updateMetadata(taskContext: TaskContext): Unit = {
 
       // if lastReadSequenceNumber exists, use AfterSequenceNumber for next Iterator


### PR DESCRIPTION
While reding aggregated Kinesis records, KCL returned the following error while deaggregating records :

`
Caused by: java.lang.NoSuchMethodError: com.google.protobuf.LazyStringList.getUnmodifiableView()Lcom/google/protobuf/LazyStringList;
        at com.amazonaws.services.kinesis.clientlibrary.types.Messages$AggregatedRecord.(Messages.java:1749)
        at com.amazonaws.services.kinesis.clientlibrary.types.Messages$AggregatedRecord.(Messages.java:1665)
        at com.amazonaws.services.kinesis.clientlibrary.types.Messages$AggregatedRecord$1.parsePartialFrom(Messages.java:1779)
        at com.amazonaws.services.kinesis.clientlibrary.types.Messages$AggregatedRecord$1.parsePartialFrom(Messages.java:1774)
`

This was because the method _getUnmodifiableView()_ was added only in 2.6.0 release of Protobuf. The version of this library used by spark by default is 2.5.0. So we are overriding the Protobuf dependency version to 2.6.0 and adding it as a shaded dependency. 

Fixes #23 