### PR TITLE
to prevent the reprocessing of already processed records after scaling the shards.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisContinousReader.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisContinousReader.scala
@@ -36,6 +36,7 @@ import org.apache.spark.util.Utils
 
 /*
  * A [[ContinuousReader]] for data from Kinesis.
+ *
  * @param sourceOptions          Kinesis consumer params to use.
  * @param streamName             Name of the Kinesis Stream.
  * @param initialPosition        The Kinesis offsets to start reading data at.
@@ -76,7 +77,7 @@ class KinesisContinuousReader(
       .getOrElse {
         val latestShards = kinesisReader.getShards()
         val latestShardInfo: Seq[ShardInfo] = if (latestShards.nonEmpty) {
-          ShardSyncer.getLatestShardInfo(latestShards, Seq.empty[ShardInfo], initialPosition, currentShardOffsets.batchId)
+          ShardSyncer.getLatestShardInfo(latestShards, Seq.empty[ShardInfo], initialPosition)
         } else {
           Seq.empty[ShardInfo]
         }
@@ -95,7 +96,6 @@ class KinesisContinuousReader(
     import scala.collection.JavaConverters._
 
     logInfo(s"Current Offset is ${currentShardOffsets.toString}")
-
     val prevShardsInfo = currentShardOffsets.shardInfo
 
     // Get the latest shard information and fetch latest ShardInformation
@@ -105,7 +105,7 @@ class KinesisContinuousReader(
       val syncedShardInfo: Seq[ShardInfo] = getLatestShardInfo(
         latestShards,
         prevShardsInfo,
-        initialPosition, currentShardOffsets.batchId)
+        initialPosition)
 
       // In Continuous processing we are unable to find out about a closed shards
       // using previous information. So we need to check if a shard is closed
@@ -237,7 +237,7 @@ case class KinesisContinuousInputPartition(
 
     val kinesisOffset = offset.asInstanceOf[KinesisSourcePartitionOffset]
     require(kinesisOffset.shardInfo == startOffset,
-      s"  shardIndo: $startOffset, but got: ${kinesisOffset.shardInfo}")
+      s"Expected shardIndo: $startOffset, but got: ${kinesisOffset.shardInfo}")
 
     new KinesisContinuousInputPartitionReader(
       kinesisOffset.shardInfo, sourceOptions,

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisContinousReader.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisContinousReader.scala
@@ -77,7 +77,7 @@ class KinesisContinuousReader(
       .getOrElse {
         val latestShards = kinesisReader.getShards()
         val latestShardInfo: Seq[ShardInfo] = if (latestShards.nonEmpty) {
-          ShardSyncer.getLatestShardInfo(latestShards, Seq.empty[ShardInfo], initialPosition)
+          ShardSyncer.getLatestShardInfo(latestShards, Seq.empty[ShardInfo], initialPosition, currentShardOffsets.batchId)
         } else {
           Seq.empty[ShardInfo]
         }
@@ -105,7 +105,8 @@ class KinesisContinuousReader(
       val syncedShardInfo: Seq[ShardInfo] = getLatestShardInfo(
         latestShards,
         prevShardsInfo,
-        initialPosition)
+        initialPosition,
+        currentShardOffsets.batchId)
 
       // In Continuous processing we are unable to find out about a closed shards
       // using previous information. So we need to check if a shard is closed

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSource.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSource.scala
@@ -57,7 +57,7 @@ private[kinesis] class KinesisSource(
     initialPosition: KinesisPosition,
     endPointURL: String,
     kinesisCredsProvider: SparkAWSCredentials
-   )
+    )
   extends Source with Serializable with Logging {
 
   import KinesisSource._
@@ -87,7 +87,7 @@ private[kinesis] class KinesisSource(
   private def metadataCommitter: MetadataCommitter[ShardInfo] = {
     metaDataCommitterType.toLowerCase(Locale.ROOT) match {
       case "hdfs" =>
-        new HDFSMetadataCommitter[ShardInfo](metaDataCommitterPath,
+        new HDFSMetadataCommitter[ ShardInfo ](metaDataCommitterPath,
           hadoopConf(sqlContext), sourceOptions)
       case _ => throw new IllegalArgumentException("only HDFS is supported")
     }
@@ -152,14 +152,13 @@ private[kinesis] class KinesisSource(
 
   /** Returns the shards position to start reading data from */
   override def getOffset: Option[Offset] = synchronized {
-
     val defaultOffset = new ShardOffsets(-1L, streamName)
     val prevBatchId = currentShardOffsets.getOrElse(defaultOffset).batchId
     val prevShardsInfo = prevBatchShardInfo(prevBatchId)
     var latestShardInfo: Array[ShardInfo] = Array.empty[ShardInfo]
 
     if (latestDescribeShardTimestamp == -1 ||
-      ((latestDescribeShardTimestamp + describeShardInterval) < System.currentTimeMillis())) {
+        ((latestDescribeShardTimestamp + describeShardInterval) < System.currentTimeMillis())) {
       val latestShards = kinesisReader.getShards()
       latestDescribeShardTimestamp = System.currentTimeMillis()
       if (latestShards.nonEmpty) {

--- a/src/main/scala/org/apache/spark/sql/kinesis/ShardSyncer.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/ShardSyncer.scala
@@ -32,7 +32,7 @@ import org.apache.spark.internal.Logging
 private[kinesis] object ShardSyncer extends Logging {
 
   private def getShardIdToChildShardsMap(latestShards: Seq[Shard]):
-  mutable.Map[String, List[String ]] = {
+    mutable.Map[String, List[String ]] = {
     val shardIdToChildShardsMap = mutable.Map.empty[String, List[String]]
 
     val shardIdToShardMap =
@@ -77,12 +77,12 @@ private[kinesis] object ShardSyncer extends Logging {
   }
 
   private[kinesis] def AddShardInfoForAncestors(
-                                                 shardId: String,
-                                                 latestShards: Seq[Shard],
-                                                 initialPosition: KinesisPosition,
-                                                 prevShardsList: mutable.Set[ String ],
-                                                 newShardsInfoMap: mutable.HashMap[ String, ShardInfo ],
-                                                 memoizationContext: mutable.Map[String, Boolean ]): Unit = {
+     shardId: String,
+     latestShards: Seq[Shard],
+     initialPosition: KinesisPosition,
+     prevShardsList: mutable.Set[ String ],
+     newShardsInfoMap: mutable.HashMap[ String, ShardInfo ],
+     memoizationContext: mutable.Map[String, Boolean ]): Unit = {
 
     val shardIdToShardMap =
       latestShards.map {
@@ -109,18 +109,18 @@ private[kinesis] object ShardSyncer extends Logging {
         if (!prevShardsList.contains(parentShardId) ) {
           logDebug("Need to create a shardInfo for shardId " + parentShardId)
           if (newShardsInfoMap.get(parentShardId).isEmpty) {
-            newShardsInfoMap.put(parentShardId,
-              new ShardInfo(parentShardId, initialPosition))
+              newShardsInfoMap.put(parentShardId,
+                new ShardInfo(parentShardId, initialPosition))
+            }
           }
-        }
       }
       memoizationContext.put(shardId, true)
     }
   }
 
   private[kinesis] def getParentShardIds(
-                                          shard: Shard,
-                                          shards: Seq[Shard]): mutable.HashSet[String] = {
+     shard: Shard,
+     shards: Seq[Shard]): mutable.HashSet[String] = {
     val parentShardIds = new mutable.HashSet[ String ]
     val parentShardId = shard.getParentShardId
     val shardIdToShardMap =
@@ -192,6 +192,7 @@ private[kinesis] object ShardSyncer extends Logging {
     prevShardsInfo.foreach {
       s: ShardInfo => prevShardsList.add(s.shardId)
     }
+
     openShards(latestShards).map {
       shardId: String =>
         if (prevShardsList.contains(shardId)) {
@@ -206,4 +207,5 @@ private[kinesis] object ShardSyncer extends Logging {
     }
     prevShardsInfo ++ newShardsInfoMap.values.toSeq
   }
+
 }


### PR DESCRIPTION
prevent the reprocessing of already processed records after scaling the shards.

resolution for issue raised :  #60


