### PR TITLE
Fix pom.xml 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
               </goals>
             </execution>
           </executions>
+          <configuration>
+            <args>
+              <arg>-nobootcp</arg>
+            </args>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -220,6 +225,10 @@
               </goals>
             </execution>
           </executions>
+          <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
* Add source and target Java version to overwrite defaults (1.5)
* Add option `-nobootcp` to scala compiler plugin (don't use boot classpath for Scala JARs)