### PR TITLE
Make DefaultAWSCredentialsProviderChain available to choose

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,11 @@ Refering $SPARK_HOME to the Spark installation directory.
 | ------------- |:-------------:| -----:|
 | streamName     | - | Name of the stream in Kinesis to read from |
 | endpointUrl     |   https://kinesis.us-east-1.amazonaws.com    |   end-point URL for Kinesis Stream|
-| awsAccessKeyId |    -     |    AWS Credentials for  Kinesis describe, read record operations|   
-| awsSecretKey |      -  |    AWS Credentials for  Kinesis describe, read record |
+| awsAccessKeyId |    -     |    AWS Credentials for Kinesis describe, read record operations |
+| awsSecretKey |      -  |    AWS Credentials for Kinesis describe, read record operations |
+| awsSTSRoleARN |      -  |    AWS STS Role ARN for Kinesis describe, read record operations |
+| awsSTSSessionName |      -  |    AWS STS Session name for Kinesis describe, read record operations |
+| awsUseInstanceProfile | true |    Use Instance Profile Credentials if none of credentials provided |
 | startingPosition |      LATEST |    Starting Position in Kinesis to fetch data from. Possible values are "latest", "trim_horizon", "earliest" (alias for trim_horizon)   |
 | failondataloss| true | fail the streaming job if any active shard is missing or expired
 | kinesis.executor.maxFetchTimeInMs |     1000 |  Maximum time spent in executor to fetch record from Kinesis per Shard |

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ Refering $SPARK_HOME to the Spark installation directory.
 | endpointUrl  | https://kinesis.us-east-1.amazonaws.com |  The aws endpoint of the kinesis Stream |
 | awsAccessKeyId |    -     |    AWS Credentials for  Kinesis describe, read record operations    
 | awsSecretKey |      -  |    AWS Credentials for  Kinesis describe, read record |
+| awsSTSRoleARN |      -  |    AWS STS Role ARN for Kinesis describe, read record operations |
+| awsSTSSessionName |      -  |    AWS STS Session name for Kinesis describe, read record operations |
+| awsUseInstanceProfile | true |    Use Instance Profile Credentials if none of credentials provided |
 | kinesis.executor.recordMaxBufferedTime | 1000 (millis) | Specify the maximum buffered time of a record |
 | kinesis.executor.maxConnections | 1 | Specify the maximum connections to Kinesis | 
 | kinesis.executor.aggregationEnabled | true | Specify if records should be aggregated before sending them to Kinesis | 

--- a/src/main/scala/org/apache/spark/sql/kinesis/CachedKinesisProducer.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/CachedKinesisProducer.scala
@@ -91,6 +91,9 @@ private[kinesis] object CachedKinesisProducer extends Logging {
     val awsStsSessionName = producerConfiguration.getOrElse(
       KinesisSourceProvider.AWS_STS_SESSION_NAME, "").toString
 
+    val awsUseInstanceProfile = producerConfiguration.getOrElse(
+      KinesisSourceProvider.AWS_USE_INSTANCE_PROFILE, "true").toBoolean
+
     val endpoint = producerConfiguration.getOrElse(
       KinesisSourceProvider.SINK_ENDPOINT_URL, KinesisSourceProvider.DEFAULT_KINESIS_ENDPOINT_URL)
       .toString
@@ -106,8 +109,10 @@ private[kinesis] object CachedKinesisProducer extends Logging {
       BasicCredentials(awsAccessKeyId, awsSecretKey)
     } else if (awsStsRoleArn.length > 0) {
       STSCredentials(awsStsRoleArn, awsStsSessionName)
-    } else {
+    } else if (awsUseInstanceProfile) {
       InstanceProfileCredentials
+    } else {
+      DefaultCredentials
     }
 
     val kinesisProducer = new Producer(new KinesisProducerConfiguration()

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceProvider.scala
@@ -85,6 +85,8 @@ private[kinesis] class KinesisSourceProvider extends DataSourceRegister
     val awsSecretKey = caseInsensitiveParams.get(AWS_SECRET_KEY).getOrElse("")
     val awsStsRoleArn = caseInsensitiveParams.get(AWS_STS_ROLE_ARN).getOrElse("")
     val awsStsSessionName = caseInsensitiveParams.get(AWS_STS_SESSION_NAME).getOrElse("")
+    val awsUseInstanceProfile = caseInsensitiveParams.getOrElse(AWS_USE_INSTANCE_PROFILE, "true")
+      .toBoolean
 
     val regionName = caseInsensitiveParams.get(REGION_NAME_KEY)
       .getOrElse(DEFAULT_KINESIS_REGION_NAME)
@@ -100,8 +102,10 @@ private[kinesis] class KinesisSourceProvider extends DataSourceRegister
       BasicCredentials(awsAccessKeyId, awsSecretKey)
     } else if (awsStsRoleArn.length > 0) {
       STSCredentials(awsStsRoleArn, awsStsSessionName)
-    } else {
+    } else if (awsUseInstanceProfile) {
       InstanceProfileCredentials
+    } else {
+      DefaultCredentials
     }
 
     new KinesisSource(
@@ -167,6 +171,9 @@ private[kinesis] class KinesisSourceProvider extends DataSourceRegister
     val awsSecretKey = caseInsensitiveParams.get(AWS_SECRET_KEY).getOrElse("")
     val awsStsRoleArn = caseInsensitiveParams.get(AWS_STS_ROLE_ARN).getOrElse("")
     val awsStsSessionName = caseInsensitiveParams.get(AWS_STS_SESSION_NAME).getOrElse("")
+    val awsUseInstanceProfile = caseInsensitiveParams.getOrElse(AWS_USE_INSTANCE_PROFILE, "true")
+      .toBoolean
+
     val failOnDataLoss = caseInsensitiveParams.get(FAILONDATALOSS)
       .getOrElse("true").toBoolean
 
@@ -181,8 +188,10 @@ private[kinesis] class KinesisSourceProvider extends DataSourceRegister
       BasicCredentials(awsAccessKeyId, awsSecretKey)
     } else if (awsStsRoleArn.length > 0) {
       STSCredentials(awsStsRoleArn, awsStsSessionName)
-    } else {
+    } else if (awsUseInstanceProfile) {
       InstanceProfileCredentials
+    } else {
+      DefaultCredentials
     }
 
     new KinesisContinuousReader(
@@ -206,6 +215,7 @@ private[kinesis] object KinesisSourceProvider extends Logging {
   private[kinesis] val AWS_SECRET_KEY = "awssecretkey"
   private[kinesis] val AWS_STS_ROLE_ARN = "awsstsrolearn"
   private[kinesis] val AWS_STS_SESSION_NAME = "awsstssessionname"
+  private[kinesis] val AWS_USE_INSTANCE_PROFILE = "awsuseinstanceprofile"
   private[kinesis] val STARTING_POSITION_KEY = "startingposition"
   private[kinesis] val FAILONDATALOSS = "failondataloss"
 


### PR DESCRIPTION
I found that with current implementation user doesn't have option to choose to use `DefaultAWSCredentialsProviderChain`. I think current behavior is bit odd: developers familiar with AWS SDK will expect applications to use default provider chain by default, not instance profile credentials.

I added new option `awsUseInstanceProfile` to choose whether to use instance profile credentials and set the default value to true to not affect the current default behavior. I also updated relevant docs.