### PR TITLE
Added session based authentication

### DIFF
--- a/src/main/scala/org/apache/spark/sql/kinesis/CachedKinesisProducer.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/CachedKinesisProducer.scala
@@ -85,6 +85,9 @@ private[kinesis] object CachedKinesisProducer extends Logging {
     val awsSecretKey = producerConfiguration.getOrElse(
       KinesisSourceProvider.AWS_SECRET_KEY, "").toString
 
+    var sessionToken = producerConfiguration.getOrElse(
+      KinesisSourceProvider.AWS_SESSION_TOKEN, "").toString
+
     val awsStsRoleArn = producerConfiguration.getOrElse(
       KinesisSourceProvider.AWS_STS_ROLE_ARN, "").toString
 
@@ -103,7 +106,11 @@ private[kinesis] object CachedKinesisProducer extends Logging {
     val region = getRegionNameByEndpoint(endpoint)
 
     val kinesisCredsProvider = if (awsAccessKeyId.length > 0) {
-      BasicCredentials(awsAccessKeyId, awsSecretKey)
+      if(sessionToken.length > 0) {
+        BasicAWSSessionCredentials(awsAccessKeyId, awsSecretKey, sessionToken)
+      } else {
+        BasicCredentials(awsAccessKeyId, awsSecretKey)
+      }
     } else if (awsStsRoleArn.length > 0) {
       STSCredentials(awsStsRoleArn, awsStsSessionName)
     } else {

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceProvider.scala
@@ -83,6 +83,7 @@ private[kinesis] class KinesisSourceProvider extends DataSourceRegister
 
     val awsAccessKeyId = caseInsensitiveParams.get(AWS_ACCESS_KEY_ID).getOrElse("")
     val awsSecretKey = caseInsensitiveParams.get(AWS_SECRET_KEY).getOrElse("")
+    val sessionToken = caseInsensitiveParams.get(AWS_SESSION_TOKEN).getOrElse("")
     val awsStsRoleArn = caseInsensitiveParams.get(AWS_STS_ROLE_ARN).getOrElse("")
     val awsStsSessionName = caseInsensitiveParams.get(AWS_STS_SESSION_NAME).getOrElse("")
 
@@ -97,7 +98,11 @@ private[kinesis] class KinesisSourceProvider extends DataSourceRegister
     val initialPosition: KinesisPosition = getKinesisPosition(caseInsensitiveParams)
 
     val kinesisCredsProvider = if (awsAccessKeyId.length > 0) {
-      BasicCredentials(awsAccessKeyId, awsSecretKey)
+      if(sessionToken.length > 0) {
+        BasicAWSSessionCredentials(awsAccessKeyId, awsSecretKey, sessionToken)
+      } else {
+        BasicCredentials(awsAccessKeyId, awsSecretKey)
+      }
     } else if (awsStsRoleArn.length > 0) {
       STSCredentials(awsStsRoleArn, awsStsSessionName)
     } else {
@@ -165,6 +170,7 @@ private[kinesis] class KinesisSourceProvider extends DataSourceRegister
 
     val awsAccessKeyId = caseInsensitiveParams.get(AWS_ACCESS_KEY_ID).getOrElse("")
     val awsSecretKey = caseInsensitiveParams.get(AWS_SECRET_KEY).getOrElse("")
+    val sessionToken = caseInsensitiveParams.get(AWS_SESSION_TOKEN).getOrElse("")
     val awsStsRoleArn = caseInsensitiveParams.get(AWS_STS_ROLE_ARN).getOrElse("")
     val awsStsSessionName = caseInsensitiveParams.get(AWS_STS_SESSION_NAME).getOrElse("")
     val failOnDataLoss = caseInsensitiveParams.get(FAILONDATALOSS)
@@ -178,7 +184,11 @@ private[kinesis] class KinesisSourceProvider extends DataSourceRegister
     val initialPosition: KinesisPosition = getKinesisPosition(caseInsensitiveParams)
 
     val kinesisCredsProvider = if (awsAccessKeyId.length > 0) {
-      BasicCredentials(awsAccessKeyId, awsSecretKey)
+      if(sessionToken.length > 0) {
+        BasicAWSSessionCredentials(awsAccessKeyId, awsSecretKey, sessionToken)
+      } else {
+        BasicCredentials(awsAccessKeyId, awsSecretKey)
+      }
     } else if (awsStsRoleArn.length > 0) {
       STSCredentials(awsStsRoleArn, awsStsSessionName)
     } else {
@@ -204,6 +214,7 @@ private[kinesis] object KinesisSourceProvider extends Logging {
   private[kinesis] val REGION_NAME_KEY = "regionname"
   private[kinesis] val AWS_ACCESS_KEY_ID = "awsaccesskeyid"
   private[kinesis] val AWS_SECRET_KEY = "awssecretkey"
+  private[kinesis] val AWS_SESSION_TOKEN = "sessiontoken"
   private[kinesis] val AWS_STS_ROLE_ARN = "awsstsrolearn"
   private[kinesis] val AWS_STS_SESSION_NAME = "awsstssessionname"
   private[kinesis] val STARTING_POSITION_KEY = "startingposition"


### PR DESCRIPTION
Should any developer is using session based authentication in local development environment, this change would enable you to provide a session token in addition to access key and secret key. Sample code in Scala: 

```
    val awsCredentials = new DefaultAWSCredentialsProviderChain().getCredentials()
    val credentials:Map[String, String] = awsCredentials match {
      case c:BasicAWSCredentials => Map("awsAccessKeyId" -> c.getAWSAccessKeyId(), "awsSecretKey" -> c.getAWSSecretKey())
      case c:BasicSessionCredentials => Map("awsAccessKeyId" -> c.getAWSAccessKeyId(), "awsSecretKey" -> c.getAWSSecretKey(), "sessionToken" -> c.getSessionToken())
      case _ => Map() //Write some code to handle this.
    }
    println(credentials)
    
    var kinesisDF = spark.readStream
      .format("kinesis")
      .option("streamName", Config.kinesisStreamName)
      .option("initialPosition", Config.kinesisPositionOption)
      .option("endpointUrl", Config.kinesisEndpoint)
      .option("region", Config.awsRegion)
      .options(credentials)
      .load()
```

If you're using a non-default AWS profile, be sure to 
`export AWS_PROFILE=YOUR_PREFERRED_PROFILE_NAME`. 