### PR TITLE
Adding ability to set exact Kinesis position to start reading from

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Refering $SPARK_HOME to the Spark installation directory.
 | awsSTSRoleARN |      -  |    AWS STS Role ARN for Kinesis describe, read record operations |
 | awsSTSSessionName |      -  |    AWS STS Session name for Kinesis describe, read record operations |
 | awsUseInstanceProfile | true |    Use Instance Profile Credentials if none of credentials provided |
-| startingPosition |      LATEST |    Starting Position in Kinesis to fetch data from. Possible values are "latest", "trim_horizon", "earliest" (alias for trim_horizon)   |
+| startingPosition |      LATEST |    Starting Position in Kinesis to fetch data from. Possible values are "latest", "trim_horizon", "earliest" (alias for trim_horizon), or JSON serialized map shardId->KinesisPosition   |
 | failondataloss| true | fail the streaming job if any active shard is missing or expired
 | kinesis.executor.maxFetchTimeInMs |     1000 |  Maximum time spent in executor to fetch record from Kinesis per Shard |
 | kinesis.executor.maxFetchRecordsPerShard |     100000 |  Maximum Number of records to fetch per shard  |

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisContinousReader.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisContinousReader.scala
@@ -47,7 +47,7 @@ import org.apache.spark.util.Utils
 class KinesisContinuousReader(
                                sourceOptions: Map[String, String],
                                streamName: String,
-                               initialPosition: KinesisPosition,
+                               initialPosition: InitialKinesisPosition,
                                endPointURL: String,
                                kinesisCredsProvider: SparkAWSCredentials,
                                failOnDataLoss: Boolean = true)

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisPosition.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisPosition.scala
@@ -79,7 +79,7 @@ private[kinesis] object KinesisPosition {
  * @param defaultPosition position that is used for shard that is requested but not present in map
  */
 private[kinesis] class InitialKinesisPosition(shardPositions: Map[String, KinesisPosition],
-                                              defaultPosition: KinesisPosition = new Latest())
+                                              defaultPosition: KinesisPosition)
   extends Serializable {
 
   def shardPosition(shardId: String): KinesisPosition =
@@ -118,13 +118,14 @@ private[kinesis] object InitialKinesisPosition {
    * @param text JSON representation of Kinesis position.
    * @return
    */
-  def fromCheckpointJson(text: String): InitialKinesisPosition = {
+  def fromCheckpointJson(text: String, defaultPosition: KinesisPosition): InitialKinesisPosition = {
     val kso = KinesisSourceOffset(text)
     val shardOffsets = kso.shardsToOffsets
 
     new InitialKinesisPosition(
       shardOffsets.shardInfoMap
-        .map(si => si._1 -> KinesisPosition.make(si._2.iteratorType, si._2.iteratorPosition))
+        .map(si => si._1 -> KinesisPosition.make(si._2.iteratorType, si._2.iteratorPosition)),
+      defaultPosition
       )
   }
 }

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisPosition.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisPosition.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.kinesis
 
+import org.json4s.NoTypeHints
+import org.json4s.jackson.Serialization
+
 trait KinesisPosition extends Serializable {
   val iteratorType: String
   val iteratorPosition: String
@@ -34,7 +37,10 @@ class Latest() extends KinesisPosition {
   override val iteratorPosition = ""
 }
 
-class AtTimeStamp(timestamp: Long) extends KinesisPosition {
+class AtTimeStamp(timestamp: String) extends KinesisPosition {
+  def this(timestamp: Long) {
+    this(timestamp.toString)
+  }
   override val iteratorType = "AT_TIMESTAMP"
   override val iteratorPosition = timestamp.toString
 }
@@ -52,4 +58,73 @@ class AtSequenceNumber(seqNumber: String) extends KinesisPosition {
 class ShardEnd() extends KinesisPosition {
   override val iteratorType = "SHARD_END"
   override val iteratorPosition = ""
+}
+
+private[kinesis] object KinesisPosition {
+  def make(iteratorType: String, iteratorPosition: String): KinesisPosition = iteratorType match {
+    case iterType if "TRIM_HORIZON".equalsIgnoreCase(iterType) => new TrimHorizon()
+    case iterType if "LATEST".equalsIgnoreCase(iterType) => new Latest()
+    case iterType if "AT_TIMESTAMP".equalsIgnoreCase(iterType) => new AtTimeStamp(iteratorPosition)
+    case iterType if "AT_SEQUENCE_NUMBER".equalsIgnoreCase(iterType) =>
+      new AtSequenceNumber(iteratorPosition)
+    case iterType if "AFTER_SEQUENCE_NUMBER".equalsIgnoreCase(iterType) =>
+      new AfterSequenceNumber(iteratorPosition)
+    case iterType if "SHARD_END".equalsIgnoreCase(iterType) => new ShardEnd()
+  }
+}
+
+/**
+ * Specifies initial position in Kenesis to start read from on the application startup.
+ * @param shardPositions map of shardId->KinesisPosition
+ * @param defaultPosition position that is used for shard that is requested but not present in map
+ */
+private[kinesis] class InitialKinesisPosition(shardPositions: Map[String, KinesisPosition],
+                                              defaultPosition: KinesisPosition = new Latest())
+  extends Serializable {
+
+  def shardPosition(shardId: String): KinesisPosition =
+    shardPositions.getOrElse(shardId, defaultPosition)
+
+  override def toString: String = s"InitialKinesisPosition($shardPositions)"
+}
+
+private[kinesis] object InitialKinesisPosition {
+  implicit val format = Serialization.formats(NoTypeHints)
+
+  def fromPredefPosition(pos: KinesisPosition): InitialKinesisPosition =
+    new InitialKinesisPosition(Map(), pos)
+
+  /**
+   * Parses json representation on Kinesis position.
+   * It is useful if Kinesis position is persisted explicitly (e.g. at the end of the batch)
+   * and used to continue reading records from the same position on Spark application redeploy.
+   * Kinesis position JSON representation example:
+   * {{{
+   * {
+   *   "shardId-000000000001":{
+   *     "iteratorType":"AFTER_SEQUENCE_NUMBER",
+   *     "iteratorPosition":"49605240428222307037115827613554798409561082419642105874"
+   *   },
+   *   "metadata":{
+   *     "streamName":"my.cool.stream2",
+   *     "batchId":"7"
+   *   },
+   *   "shardId-000000000000":{
+   *     "iteratorType":"AFTER_SEQUENCE_NUMBER",
+   *     "iteratorPosition":"49605240428200006291917297020490128157480794051565322242"
+   *   }
+   * }
+   * }}}
+   * @param text JSON representation of Kinesis position.
+   * @return
+   */
+  def fromCheckpointJson(text: String): InitialKinesisPosition = {
+    val kso = KinesisSourceOffset(text)
+    val shardOffsets = kso.shardsToOffsets
+
+    new InitialKinesisPosition(
+      shardOffsets.shardInfoMap
+        .map(si => si._1 -> KinesisPosition.make(si._2.iteratorType, si._2.iteratorPosition))
+      )
+  }
 }

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSource.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSource.scala
@@ -54,7 +54,7 @@ private[kinesis] class KinesisSource(
     sourceOptions: Map[String, String],
     metadataPath: String,
     streamName: String,
-    initialPosition: KinesisPosition,
+    initialPosition: InitialKinesisPosition,
     endPointURL: String,
     kinesisCredsProvider: SparkAWSCredentials,
     failOnDataLoss: Boolean = true

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceProvider.scala
@@ -250,7 +250,8 @@ private[kinesis] object KinesisSourceProvider extends Logging {
         InitialKinesisPosition.fromPredefPosition(new TrimHorizon)
       case Some(position) if position.toLowerCase(Locale.ROOT) == "earliest" =>
         InitialKinesisPosition.fromPredefPosition(new TrimHorizon)
-      case Some(json) => InitialKinesisPosition.fromCheckpointJson(json)
+      case Some(json) =>
+        InitialKinesisPosition.fromCheckpointJson(json, new AtTimeStamp(CURRENT_TIMESTAMP))
       case None => InitialKinesisPosition.fromPredefPosition(new AtTimeStamp(CURRENT_TIMESTAMP))
     }
   }

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceProvider.scala
@@ -97,7 +97,7 @@ private[kinesis] class KinesisSourceProvider extends DataSourceRegister
     val failOnDataLoss = caseInsensitiveParams.get(FAILONDATALOSS)
       .getOrElse("true").toBoolean
 
-    val initialPosition: KinesisPosition = getKinesisPosition(caseInsensitiveParams)
+    val initialPosition: InitialKinesisPosition = getKinesisPosition(caseInsensitiveParams)
 
     val kinesisCredsProvider = if (awsAccessKeyId.length > 0) {
       if(sessionToken.length > 0) {
@@ -188,7 +188,7 @@ private[kinesis] class KinesisSourceProvider extends DataSourceRegister
     val endPointURL = caseInsensitiveParams.get(END_POINT_URL)
       .getOrElse(DEFAULT_KINESIS_ENDPOINT_URL)
 
-    val initialPosition: KinesisPosition = getKinesisPosition(caseInsensitiveParams)
+    val initialPosition: InitialKinesisPosition = getKinesisPosition(caseInsensitiveParams)
 
     val kinesisCredsProvider = if (awsAccessKeyId.length > 0) {
       if(sessionToken.length > 0) {
@@ -241,17 +241,17 @@ private[kinesis] object KinesisSourceProvider extends Logging {
 
 
   private[kinesis] def getKinesisPosition(
-      params: Map[String, String]): KinesisPosition = {
-    // TODO Support custom shards positions
+      params: Map[String, String]): InitialKinesisPosition = {
     val CURRENT_TIMESTAMP = System.currentTimeMillis
     params.get(STARTING_POSITION_KEY).map(_.trim) match {
       case Some(position) if position.toLowerCase(Locale.ROOT) == "latest" =>
-        new AtTimeStamp(CURRENT_TIMESTAMP)
+        InitialKinesisPosition.fromPredefPosition(new AtTimeStamp(CURRENT_TIMESTAMP))
       case Some(position) if position.toLowerCase(Locale.ROOT) == "trim_horizon" =>
-        new TrimHorizon
+        InitialKinesisPosition.fromPredefPosition(new TrimHorizon)
       case Some(position) if position.toLowerCase(Locale.ROOT) == "earliest" =>
-        new TrimHorizon
-      case None => new AtTimeStamp(CURRENT_TIMESTAMP)
+        InitialKinesisPosition.fromPredefPosition(new TrimHorizon)
+      case Some(json) => InitialKinesisPosition.fromCheckpointJson(json)
+      case None => InitialKinesisPosition.fromPredefPosition(new AtTimeStamp(CURRENT_TIMESTAMP))
     }
   }
 

--- a/src/main/scala/org/apache/spark/sql/kinesis/ShardSyncer.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/ShardSyncer.scala
@@ -79,7 +79,7 @@ private[kinesis] object ShardSyncer extends Logging {
   private[kinesis] def AddShardInfoForAncestors(
      shardId: String,
      latestShards: Seq[Shard],
-     initialPosition: KinesisPosition,
+     initialPosition: InitialKinesisPosition,
      prevShardsList: mutable.Set[ String ],
      newShardsInfoMap: mutable.HashMap[ String, ShardInfo ],
      memoizationContext: mutable.Map[String, Boolean ]): Unit = {
@@ -111,7 +111,7 @@ private[kinesis] object ShardSyncer extends Logging {
           logDebug("Need to create a shardInfo for shardId " + parentShardId)
           if (newShardsInfoMap.get(parentShardId).isEmpty) {
               newShardsInfoMap.put(parentShardId,
-                new ShardInfo(parentShardId, initialPosition))
+                new ShardInfo(parentShardId, initialPosition.shardPosition(parentShardId)))
             }
           }
       }
@@ -193,7 +193,7 @@ private[kinesis] object ShardSyncer extends Logging {
   def getLatestShardInfo(
       latestShards: Seq[Shard],
       prevShardsInfo: Seq[ShardInfo],
-      initialPosition: KinesisPosition,
+      initialPosition: InitialKinesisPosition,
       failOnDataLoss: Boolean = true): Seq[ShardInfo] = {
 
     if (latestShards.isEmpty) {
@@ -250,7 +250,7 @@ private[kinesis] object ShardSyncer extends Logging {
           AddShardInfoForAncestors(shardId,
             latestShards, initialPosition, prevShardsList, newShardsInfoMap, memoizationContext)
           newShardsInfoMap.put(shardId,
-            new ShardInfo(shardId, initialPosition))
+            new ShardInfo(shardId, initialPosition.shardPosition(shardId)))
         }
     }
     filteredPrevShardsInfo ++ newShardsInfoMap.values.toSeq

--- a/src/test/scala/org/apache/spark/sql/kinesis/KinesisPositionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/kinesis/KinesisPositionSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.kinesis
+
+import org.apache.spark.SparkFunSuite
+
+class KinesisPositionSuite extends SparkFunSuite {
+
+  test("Fail on invalid kinesis source offset JSON") {
+    assertThrows[IllegalArgumentException] {
+      InitialKinesisPosition.fromCheckpointJson("""{"a":5}""", new TrimHorizon())
+    }
+  }
+
+  test("Construct initial position from KinesisSourceOffset JSON") {
+    // Given
+    val shard00 = new AfterSequenceNumber("111")
+    val shard01 = new AfterSequenceNumber("222")
+    val offset = KinesisSourceOffset(
+      ShardOffsets(
+        batchId = 5L,
+        streamName = "my.stream",
+        shardInfoMap = Map(
+          "shardId-00" -> ShardInfo("shardId-00", shard00.iteratorType, shard00.iteratorPosition),
+          "shardId-01" -> ShardInfo("shardId-01", shard01.iteratorType, shard01.iteratorPosition)
+        )
+      )
+    )
+    val offsetJson = offset.json
+
+    // When
+    val initPos = InitialKinesisPosition.fromCheckpointJson(offsetJson, new TrimHorizon())
+
+    // Expected
+    val shard00Result = initPos.shardPosition("shardId-00")
+    assertResult(shard00Result.iteratorType)(shard00.iteratorType)
+    assertResult(shard00Result.iteratorPosition)(shard00.iteratorPosition)
+
+    val shard01Result = initPos.shardPosition("shardId-01")
+    assertResult(shard01Result.iteratorType)(shard01.iteratorType)
+    assertResult(shard01Result.iteratorPosition)(shard01.iteratorPosition)
+
+    // Should give default position for a newly discovered shard
+    val shard02Result = initPos.shardPosition("shardId-02")
+    assertResult(shard02Result.iteratorType)(new TrimHorizon().iteratorType)
+    assertResult(shard02Result.iteratorPosition)(new TrimHorizon().iteratorPosition)
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/kinesis/ShardSyncerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/kinesis/ShardSyncerSuite.scala
@@ -29,14 +29,16 @@ class ShardSyncerSuite extends SparkFunSuite with SharedSQLContext {
 
   test("Should error out when failondataloss is true and a shard is deleted") {
     val ex = intercept[ IllegalStateException ] {
-      ShardSyncer.getLatestShardInfo(latestShards, prevShardInfo, new TrimHorizon, true)
+      ShardSyncer.getLatestShardInfo(latestShards, prevShardInfo,
+        InitialKinesisPosition.fromPredefPosition(new TrimHorizon), true)
     }
   }
 
   test("Should error out when failondataloss is false and a shard is deleted") {
     val expectedShardInfo = Seq(new ShardInfo("Shard1", new TrimHorizon))
     val latest: Seq[ShardInfo] = ShardSyncer.getLatestShardInfo(
-      latestShards, prevShardInfo, new TrimHorizon, false)
+      latestShards, prevShardInfo, InitialKinesisPosition.fromPredefPosition(new TrimHorizon),
+      false)
     assert(latest.nonEmpty)
     assert(latest(0).shardId === "Shard1")
     assert(latest(0).iteratorType === new TrimHorizon().iteratorType )


### PR DESCRIPTION
This change should add the ability to specify starting Kinesis position to read from by passing a JSON containing sequence numbers for each shard directly to `"startingposition"` option.

----

_A bit of background_
In our spark structured stream application, we have a listener (`org.apache.spark.sql.streaming.StreamingQueryListener`) that manually persists `SourceProgress.endOffset` (which is a JSON string) to an external storage after each batch. And in case of quoble/kinesis-sql it looks like:
```
{
  "shardId-000000000001":{
    "iteratorType":"AFTER_SEQUENCE_NUMBER",
    "iteratorPosition":"49605240428222307037115827613554798409561082419642105874"
  },
  "metadata":{
    "streamName":"my.stream.name1",
    "batchId":"7"
  },
  "shardId-000000000000":{
    "iteratorType":"AFTER_SEQUENCE_NUMBER",
    "iteratorPosition":"49605240428200006291917297020490128157480794051565322242"
  }
}
```
And we need to be able to pick up this JSON on application re-deploy and continue processing from the last position (at-least-once semantics is ok for us).

[kafka-0-10-sql](https://github.com/apache/spark/tree/master/external/kafka-0-10-sql) allows to pass a JSON searilized offset as "startingOffsets" option, and continue reading from the last position.
While moving one of spark jobs to Kinesis we've realized that such functionality is missing.

By this change I'd like to add an ability to specify Kinesis initial position, by passing JSON serialized map shardId->ShardInfo to `"startingposition"` option.

----

This implementation is already tested on our environment.
(I understand it may  be similar to https://github.com/qubole/kinesis-sql/pull/65)