### PR TITLE
Fixing Kinesis Sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ Refering $SPARK_HOME to the Spark installation directory.
 | awsUseInstanceProfile | true |    Use Instance Profile Credentials if none of credentials provided |
 | kinesis.executor.recordMaxBufferedTime | 1000 (millis) | Specify the maximum buffered time of a record |
 | kinesis.executor.maxConnections | 1 | Specify the maximum connections to Kinesis | 
-| kinesis.executor.aggregationEnabled | true | Specify if records should be aggregated before sending them to Kinesis | 
+| kinesis.executor.aggregationEnabled | true | Specify if records should be aggregated before sending them to Kinesis |
+| kniesis.executor.flushwaittimemillis | 100 | Wait time while flushing records to Kinesis on Task End |
 
 ## Roadmap
 *  We need to migrate to DataSource V2 APIs for MicroBatchExecution.

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceProvider.scala
@@ -238,6 +238,7 @@ private[kinesis] object KinesisSourceProvider extends Logging {
   private[kinesis] val SINK_RECORD_MAX_BUFFERED_TIME = "kinesis.executor.recordmaxbufferedtime"
   private[kinesis] val SINK_MAX_CONNECTIONS = "kinesis.executor.maxconnections"
   private[kinesis] val SINK_AGGREGATION_ENABLED = "kinesis.executor.aggregationenabled"
+  private[kinesis] val SINK_FLUSH_WAIT_TIME_MILLIS = "kniesis.executor.flushwaittimemillis"
 
 
   private[kinesis] def getKinesisPosition(
@@ -266,6 +267,8 @@ private[kinesis] object KinesisSourceProvider extends Logging {
   private[kinesis] val DEFAULT_SINK_MAX_CONNECTIONS: String = "1"
 
   private[kinesis] val DEFAULT_SINK_AGGREGATION: String = "true"
+
+  private[kinesis] val DEFAULT_FLUSH_WAIT_TIME_MILLIS: String = "100"
 }
 
 


### PR DESCRIPTION
### What was the issue?

Kinesis sink was experiencing slowness in writing records as raised in Issue #47 

### Issue Analysis

Method flushSync was being called at every step of the iterator. flushSync adds a sleep time of at least 500 milliseconds because of its implementation.
```
public void flushSync() {
        while (getOutstandingRecordsCount() > 0) {
            flush();
            try {
                Thread.sleep(500);
            } catch (InterruptedException e) { }
        }
    }
```

### Proposed Solution

We can flush records before task completion and not at every step of the iterator. These code changes also reduce sleep time and make changes related to error handling.