### PR TITLE
Remove lastReadSequenceNumber.isEmpty condition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.qubole.spark</groupId>
-  <artifactId>spark-sql-kinesis_2.11</artifactId>
+  <artifactId>spark-sql-kinesis_2.12</artifactId>
   <version>1.1.4_spark-2.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Kinesis Integration for Structured Streaming</name>
@@ -50,7 +50,7 @@
     <connection>scm:git:git://github.com/qubole/kinesis-sql.git</connection>
     <url>http://github.com/qubole/kinesis-sql</url>
     <developerConnection>scm:git:git@github.com:qubole/kinesis-sql.git</developerConnection>
-    <tag>spark-sql-kinesis_2.11-0.5.0-spark_2.4</tag>
+    <tag>spark-sql-kinesis_2.12-0.5.0-spark_2.4</tag>
   </scm>
 
   <inceptionYear>2018</inceptionYear>
@@ -62,7 +62,7 @@
   <properties>
     <sbt.project.name>sql-kinesis</sbt.project.name>
     <spark.version>2.4.0</spark.version>
-    <scala.binary.version>2.11</scala.binary.version>
+    <scala.binary.version>2.12</scala.binary.version>
     <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -140,7 +140,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.11</artifactId>
+      <artifactId>scalatest_2.12</artifactId>
       <version>3.0.3</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.qubole.spark</groupId>
-  <artifactId>spark-sql-kinesis_2.12</artifactId>
+  <artifactId>spark-sql-kinesis_2.11</artifactId>
   <version>1.1.4_spark-2.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Kinesis Integration for Structured Streaming</name>
@@ -50,7 +50,7 @@
     <connection>scm:git:git://github.com/qubole/kinesis-sql.git</connection>
     <url>http://github.com/qubole/kinesis-sql</url>
     <developerConnection>scm:git:git@github.com:qubole/kinesis-sql.git</developerConnection>
-    <tag>spark-sql-kinesis_2.12-0.5.0-spark_2.4</tag>
+    <tag>spark-sql-kinesis_2.11-0.5.0-spark_2.4</tag>
   </scm>
 
   <inceptionYear>2018</inceptionYear>
@@ -62,7 +62,7 @@
   <properties>
     <sbt.project.name>sql-kinesis</sbt.project.name>
     <spark.version>2.4.0</spark.version>
-    <scala.binary.version>2.12</scala.binary.version>
+    <scala.binary.version>2.11</scala.binary.version>
     <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -140,7 +140,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.12</artifactId>
+      <artifactId>scalatest_2.11</artifactId>
       <version>3.0.3</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceRDD.scala
@@ -165,17 +165,7 @@ private[kinesis] class KinesisSourceRDD(
       }
 
       def canFetchMoreRecords(currentTimestamp: Long): Boolean = {
-        if (lastReadSequenceNumber.isEmpty) {
-          // We are not using timestamp as offset. So we have to make sure that
-          //    a) we reach the tip of the stream if we have not able to
-          //    b) we read at-least one records
-          // so that we are never stuck in the loop where we have data near the tip of the stream
-          // but we are not spending enough time to read it
-          true
-        } else {
-          // honour the maxFetchTime provided in the options.
-          currentTimestamp - startTimestamp < maxFetchTimeInMs
-        }
+        currentTimestamp - startTimestamp < maxFetchTimeInMs
       }
 
       def addDelayInFetchingRecords(currentTimestamp: Long): Unit = {

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceRDD.scala
@@ -165,7 +165,18 @@ private[kinesis] class KinesisSourceRDD(
       }
 
       def canFetchMoreRecords(currentTimestamp: Long): Boolean = {
-        currentTimestamp - startTimestamp < maxFetchTimeInMs
+        val iteratorType: String = sourcePartition.shardInfo.iteratorType
+        if (lastReadSequenceNumber.isEmpty && iteratorType != "AT_TIMESTAMP") {
+          // We are not using timestamp as offset. So we have to make sure that
+          //    a) we reach the tip of the stream if we have not able to
+          //    b) we read at-least one records
+          // so that we are never stuck in the loop where we have data near the tip of the stream
+          // but we are not spending enough time to read it
+          true
+        } else {
+          // honour the maxFetchTime provided in the options.
+          currentTimestamp - startTimestamp < maxFetchTimeInMs
+        }
       }
 
       def addDelayInFetchingRecords(currentTimestamp: Long): Unit = {

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisSourceRDD.scala
@@ -165,18 +165,7 @@ private[kinesis] class KinesisSourceRDD(
       }
 
       def canFetchMoreRecords(currentTimestamp: Long): Boolean = {
-        val iteratorType: String = sourcePartition.shardInfo.iteratorType
-        if (lastReadSequenceNumber.isEmpty && iteratorType != "AT_TIMESTAMP") {
-          // We are not using timestamp as offset. So we have to make sure that
-          //    a) we reach the tip of the stream if we have not able to
-          //    b) we read at-least one records
-          // so that we are never stuck in the loop where we have data near the tip of the stream
-          // but we are not spending enough time to read it
-          true
-        } else {
-          // honour the maxFetchTime provided in the options.
-          currentTimestamp - startTimestamp < maxFetchTimeInMs
-        }
+        currentTimestamp - startTimestamp < maxFetchTimeInMs
       }
 
       def addDelayInFetchingRecords(currentTimestamp: Long): Unit = {


### PR DESCRIPTION
Fixes bug https://github.com/qubole/kinesis-sql/issues/87.

This condition causes an infinite loop and throttling from AWS when the shard is empty. In my example on the ticket, I show it hitting the Kinesis API iteratively for minutes before giving up on the shard. We should more gracefully handle empty shards which admit no `lastReadSequenceNumber` no matter how many times you hit them sequentially.

Moreover, I believe the condition is unnecessary, because one can just increase `maxReadTimeInMs` if you want to spend a longer time reading on the shard.