### PR TITLE
client execution timeout configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Refering $SPARK_HOME to the Spark installation directory.
 | kinesis.client.numRetries |     3 |  Maximum Number of retries for Kinesis API requests  |
 | kinesis.client.retryIntervalMs |     1000 |  Cool-off period before retrying Kinesis API  |
 | kinesis.client.maxRetryIntervalMs	| 10000	| Max Cool-off period between 2 retries	|
+| kinesis.client.clientExecutionTimeout | 0 | Amazon SDK client execution timeout |
 | kinesis.client.avoidEmptyBatches| false | Avoid creating an empty microbatch job by checking upfront if there are any unread data in the stream before the batch is started
 
 ## Kinesis Sink Configuration

--- a/src/test/scala/org/apache/spark/sql/kinesis/KinesisSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/kinesis/KinesisSourceSuite.scala
@@ -124,6 +124,9 @@ class KinesisSourceOptionsSuite extends StreamTest with SharedSparkSession {
       ("kinesis.executor.maxFetchTimeInMs", "10000"),
       ("kinesis.client.numRetries", "2")
     )
+    testKinesisOptions(
+      ("kinesis.client.clientExecutionTimeout", "20000")
+    )
   }
 
   test("test for failOnDataLoss") {


### PR DESCRIPTION
From AWS SDK doc:
> This timeout covers the entire client execution except for marshalling. This includes request handler execution, all HTTP request including retries, unmarshalling, etc.
...
A non-positive value disables this feature.

https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#getClientExecutionTimeout-- 