### PR TITLE
Fix stream dying after a period of inactivity; fix build for Spark 3.2.1.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+kinesis-spark-connector_2.12-1.2.1_spark-3.2
+----------------------------
+- Update the build configuration and source code to build aginst Spark 3.2.1 [Ron Cemer]
+
 kinesis_2.12-1.2.0_spark-3.0
 ----------------------------
 - Support for Spark 3.0 and scala 2.12 (#92) [Vikram Agrawal, Vikram

--- a/README.md
+++ b/README.md
@@ -1,23 +1,22 @@
-[![Build Status](https://travis-ci.org/qubole/kinesis-sql.svg?branch=master)](https://travis-ci.org/qubole/kinesis-sql)
-
 # Kinesis Connector for Structured Streaming 
 
 Implementation of Kinesis Source Provider in Spark Structured Streaming. [SPARK-18165](https://issues.apache.org/jira/browse/SPARK-18165) describes the need for such implementation. More details on the implementation can be read in this [blog](https://www.qubole.com/blog/kinesis-connector-for-structured-streaming/)
+
+This is a fork of https://github.com/qubole/kinesis-sql with the build configuration and source code updated for building against Spark 3.2.1 in order to fix a number of bugs involving the consumer not receiving new messages after a period of no new messages being added to the Kinesis data stream.
 
 ## Downloading and Using the Connector
 
 The connector is available from the Maven Central repository. It can be used using the --packages option or the spark.jars.packages configuration property. Use the following connector artifact
 
-	Spark 3.0: com.qubole.spark/spark-sql-kinesis_2.12/1.2.0-spark_3.0
-	Spark 2.4: com.qubole.spark/spark-sql-kinesis_2.11/1.2.0-spark_2.4
+	Spark 3.2: com.roncemer.spark/spark-sql-kinesis_2.12/1.2.1-spark_3.2
 
 ## Developer Setup
-Checkout kinesis-sql branch depending upon your Spark version. Use Master branch for the latest Spark version 
+Checkout kinesis-spark-connector branch depending upon your Spark version. Use Master branch for the latest Spark version 
 
-###### Spark version 3.0.x
-	git clone git@github.com:qubole/kinesis-sql.git
+###### Spark version 3.2.x
+	git clone git@github.com:roncemer/kinesis-spark-connector.git
 	git checkout master
-	cd kinesis-sql
+	cd kinesis-spark-connector
 	mvn install -DskipTests
 
 This will create *target/spark-sql-kinesis_2.12-\*.jar* file which contains the connector code and its dependency jars.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a fork of https://github.com/qubole/kinesis-sql with the build configura
 
 The connector is available from the Maven Central repository. It can be used using the --packages option or the spark.jars.packages configuration property. Use the following connector artifact
 
-	Spark 3.2: com.roncemer.spark/spark-sql-kinesis_2.12/1.2.1-spark_3.2
+	Spark 3.2: com.roncemer.spark/kinesis-spark-connector_2.12/1.2.1-spark_3.2
 
 ## Developer Setup
 Checkout kinesis-spark-connector branch depending upon your Spark version. Use Master branch for the latest Spark version 
@@ -19,7 +19,7 @@ Checkout kinesis-spark-connector branch depending upon your Spark version. Use M
 	cd kinesis-spark-connector
 	mvn install -DskipTests
 
-This will create *target/spark-sql-kinesis_2.12-\*.jar* file which contains the connector code and its dependency jars.
+This will create *target/kinesis-spark-connector_2.12-1.2.1_spark-3.2.jar* file which contains the connector code and its dependency jars.
 
 
 ## How to use it
@@ -45,7 +45,7 @@ Refering $SPARK_HOME to the Spark installation directory.
 
 ###### Open Spark-Shell
 
-	$SPARK_HOME/bin/spark-shell --jars target/spark-sql-kinesis_2.11-2.2.0.jar
+	$SPARK_HOME/bin/spark-shell --jars target/kinesis-spark-connector_2.12-1.2.1_spark-3.2.jar
 
 ###### Subscribe to Kinesis Source
 	// Subscribe the "test" stream

--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 Implementation of Kinesis Source Provider in Spark Structured Streaming. [SPARK-18165](https://issues.apache.org/jira/browse/SPARK-18165) describes the need for such implementation. More details on the implementation can be read in this [blog](https://www.qubole.com/blog/kinesis-connector-for-structured-streaming/)
 
-This is a fork of https://github.com/qubole/kinesis-sql with the build configuration and source code updated for building against Spark 3.2.1 in order to fix a number of bugs involving the consumer not receiving new messages after a period of no new messages being added to the Kinesis data stream.
-
 ## Downloading and Using the Connector
 
 The connector is available from the Maven Central repository. It can be used using the --packages option or the spark.jars.packages configuration property. Use the following connector artifact
 
-	Spark 3.2: com.roncemer.spark/kinesis-spark-connector_2.12/1.2.1-spark_3.2
+	Spark 3.2: com.qubole.spark/kinesis-sql_2.12/1.2.1-spark_3.2
+	Spark 3.0: com.qubole.spark/spark-sql-kinesis_2.12/1.2.0-spark_3.0
+	Spark 2.4: com.qubole.spark/spark-sql-kinesis_2.11/1.2.0-spark_2.4
 
 ## Developer Setup
-Checkout kinesis-spark-connector branch depending upon your Spark version. Use Master branch for the latest Spark version 
+Checkout kinesis-sql branch depending upon your Spark version. Use Master branch for the latest Spark version 
 
 ###### Spark version 3.2.x
-	git clone git@github.com:roncemer/kinesis-spark-connector.git
+	git clone git@github.com:qubole/kinesis-sql.git
 	git checkout master
-	cd kinesis-spark-connector
+	cd kinesis-sql
 	mvn install -DskipTests
 
-This will create *target/kinesis-spark-connector_2.12-1.2.1_spark-3.2.jar* file which contains the connector code and its dependency jars.
+This will create *target/spark-sql-kinesis_2.12-\*.jar* file which contains the connector code and its dependency jars.
 
 
 ## How to use it
@@ -45,7 +45,7 @@ Refering $SPARK_HOME to the Spark installation directory.
 
 ###### Open Spark-Shell
 
-	$SPARK_HOME/bin/spark-shell --jars target/kinesis-spark-connector_2.12-1.2.1_spark-3.2.jar
+	$SPARK_HOME/bin/spark-shell --jars target/spark-sql-kinesis_2.11-2.2.0.jar
 
 ###### Subscribe to Kinesis Source
 	// Subscribe the "test" stream

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kinesis Connector for Structured Streaming 
+# Kinesis Connector for Spark Structured Streaming 
 
 Implementation of Kinesis Source Provider in Spark Structured Streaming. [SPARK-18165](https://issues.apache.org/jira/browse/SPARK-18165) describes the need for such implementation. More details on the implementation can be read in this [blog](https://www.qubole.com/blog/kinesis-connector-for-structured-streaming/)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Checkout kinesis-sql branch depending upon your Spark version. Use Master branch
 	cd kinesis-sql
 	mvn install -DskipTests
 
-This will create *target/spark-sql-kinesis_2.12-\*.jar* file which contains the connector code and its dependency jars.
+This will create *target/spark-sql-kinesis_2.12-1.2.1_spark-3.2.jar* file which contains the connector code and its dependency jars.
 
 
 ## How to use it
@@ -45,7 +45,7 @@ Refering $SPARK_HOME to the Spark installation directory.
 
 ###### Open Spark-Shell
 
-	$SPARK_HOME/bin/spark-shell --jars target/spark-sql-kinesis_2.11-2.2.0.jar
+	$SPARK_HOME/bin/spark-shell --jars target/spark-sql-kinesis_2.12-1.2.1_spark-3.2.jar
 
 ###### Subscribe to Kinesis Source
 	// Subscribe the "test" stream

--- a/pom.xml
+++ b/pom.xml
@@ -18,24 +18,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.roncemer.spark</groupId>
-  <artifactId>kinesis-spark-connector-2.12</artifactId>
+  <groupId>com.qubole.spark</groupId>
+  <artifactId>spark-sql-kinesis_2.12</artifactId>
   <version>1.2.1_spark-3.2</version>
   <packaging>jar</packaging>
   <name>Kinesis Integration for Structured Streaming</name>
   <description>Connector to read from and write into Kinesis from Structured Streaming Applications</description>
-  <url>http://github.com/roncemer/kinesis-spark-connector</url>
+  <url>http://github.com/qubole/kinesis-sql</url>
 
 
   <developers>
-    <developer>
-      <id>roncemer</id>
-      <organization>Ron Cemer</organization>
-      <organizationUrl>https://roncemer.com</organizationUrl>
-      <roles>
-        <role>developer</role>
-      </roles>
-    </developer>
     <developer>
       <id>qubole</id>
       <organization>Qubole Inc.</organization>
@@ -49,16 +41,16 @@
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>https://github.com/roncemer/kinesis-spark-connector/blob/master/LICENSE</url>
+      <url>https://github.com/qubole/kinesis-sql/blob/master/LICENSE</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
 
   <scm>
-    <connection>scm:git:git://github.com/roncemer/kinesis-spark-connector.git</connection>
-    <url>http://github.com/roncemer/kinesis-spark-connector</url>
-    <developerConnection>scm:git:git@github.com:roncemer/kinesis-spark-connector.git</developerConnection>
-    <tag>kinesis-spark-connector-2.12_1.2.1_spark-3.2</tag>
+    <connection>scm:git:git://github.com/qubole/kinesis-sql.git</connection>
+    <url>http://github.com/qubole/kinesis-sql</url>
+    <developerConnection>scm:git:git@github.com:qubole/kinesis-sql.git</developerConnection>
+    <tag>spark-sql-kinesis-2.12_1.2.1_spark-3.2</tag>
   </scm>
 
   <inceptionYear>2018</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.qubole.spark</groupId>
-  <artifactId>spark-sql-kinesis_2.12</artifactId>
+  <artifactId>kinesis-spark-connector_2.12</artifactId>
   <version>1.2.1_spark-3.2</version>
   <packaging>jar</packaging>
   <name>Kinesis Integration for Structured Streaming</name>
   <description>Connector to read from and write into Kinesis from Structured Streaming Applications</description>
-  <url>http://github.com/qubole/kinesis-sql</url>
+  <url>http://github.com/roncemer/kinesis-spark-connector</url>
 
 
   <developers>
@@ -41,16 +41,16 @@
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>https://github.com/qubole/kinesis-sql/blob/master/LICENSE.txt</url>
+      <url>https://github.com/roncemer/kinesis-spark-connector/blob/master/LICENSE.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
 
   <scm>
-    <connection>scm:git:git://github.com/qubole/kinesis-sql.git</connection>
-    <url>http://github.com/qubole/kinesis-sql</url>
-    <developerConnection>scm:git:git@github.com:qubole/kinesis-sql.git</developerConnection>
-    <tag>spark-sql-kinesis_2.12-1.2.0-spark_3.0</tag>
+    <connection>scm:git:git://github.com/roncemer/kinesis-spark-connector.git</connection>
+    <url>http://github.com/roncemer/kinesis-spark-connector</url>
+    <developerConnection>scm:git:git@github.com:roncemer/kinesis-spark-connector.git</developerConnection>
+    <tag>kinesis-spark-connector_2.12-1.2.1-spark_3.1</tag>
   </scm>
 
   <inceptionYear>2018</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.qubole.spark</groupId>
-  <artifactId>kinesis-spark-connector_2.12</artifactId>
+  <groupId>com.roncemer.spark</groupId>
+  <artifactId>kinesis-spark-connector-2.12</artifactId>
   <version>1.2.1_spark-3.2</version>
   <packaging>jar</packaging>
   <name>Kinesis Integration for Structured Streaming</name>
@@ -28,6 +28,14 @@
 
 
   <developers>
+    <developer>
+      <id>roncemer</id>
+      <organization>Ron Cemer</organization>
+      <organizationUrl>https://roncemer.com</organizationUrl>
+      <roles>
+        <role>developer</role>
+      </roles>
+    </developer>
     <developer>
       <id>qubole</id>
       <organization>Qubole Inc.</organization>
@@ -41,7 +49,7 @@
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>https://github.com/roncemer/kinesis-spark-connector/blob/master/LICENSE.txt</url>
+      <url>https://github.com/roncemer/kinesis-spark-connector/blob/master/LICENSE</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -50,7 +58,7 @@
     <connection>scm:git:git://github.com/roncemer/kinesis-spark-connector.git</connection>
     <url>http://github.com/roncemer/kinesis-spark-connector</url>
     <developerConnection>scm:git:git@github.com:roncemer/kinesis-spark-connector.git</developerConnection>
-    <tag>kinesis-spark-connector_2.12-1.2.1-spark_3.1</tag>
+    <tag>kinesis-spark-connector-2.12_1.2.1_spark-3.2</tag>
   </scm>
 
   <inceptionYear>2018</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.qubole.spark</groupId>
   <artifactId>spark-sql-kinesis_2.12</artifactId>
-  <version>1.2.1_spark-3.0-SNAPSHOT</version>
+  <version>1.2.1_spark-3.2</version>
   <packaging>jar</packaging>
   <name>Kinesis Integration for Structured Streaming</name>
   <description>Connector to read from and write into Kinesis from Structured Streaming Applications</description>
@@ -61,9 +61,9 @@
 
   <properties>
     <sbt.project.name>sql-kinesis</sbt.project.name>
-    <spark.version>3.0.1</spark.version>
+    <spark.version>3.2.1</spark.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.13.4</fasterxml.jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -99,27 +99,27 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>1.9.0</version>
+      <version>1.14.8</version>
     </dependency>
     <dependency>
     <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.11.655</version>
+      <version>1.12.302</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.11.271</version>
+      <version>1.12.302</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-kinesis-producer</artifactId>
-      <version>0.12.8</version>
+      <version>0.14.13</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.6.1</version>
+      <version>3.21.6</version>
       <!--
          We are being explicit about version here and overriding the
          spark default of 2.5.0 because KCL appears to have introduced
@@ -134,19 +134,19 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.1.0</version>
+      <version>4.8.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
-      <version>1.14.2</version>
+      <version>1.16.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>3.0.8</version>
+      <version>3.2.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <sbt.project.name>sql-kinesis</sbt.project.name>
     <spark.version>3.2.1</spark.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <fasterxml.jackson.version>2.13.4</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.12.3</fasterxml.jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -110,13 +110,8 @@
       <version>1.14.8</version>
     </dependency>
     <dependency>
-    <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.12.302</version>
-    </dependency>
-    <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sts</artifactId>
+      <artifactId>aws-java-sdk</artifactId>
       <version>1.12.302</version>
     </dependency>
     <dependency>
@@ -133,6 +128,21 @@
          spark default of 2.5.0 because KCL appears to have introduced
          a dependency on protobuf 2.6.1 somewhere between KCL 1.4.0 and 1.6.1.
        -->
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${fasterxml.jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${fasterxml.jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -135,9 +135,9 @@ This file is divided into 3 sections:
   <!-- ??? usually shouldn't be checked into the code base. -->
   <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"></check>
 
-  <!-- As of SPARK-7558, all tests in Spark should extend o.a.s.SparkFunSuite instead of FunSuite directly -->
+  <!-- As of SPARK-7558, all tests in Spark should extend o.a.s.SparkFunSuite instead of AnyFunSuite directly -->
   <check customId="funsuite" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
-    <parameters><parameter name="regex">^FunSuite[A-Za-z]*$</parameter></parameters>
+    <parameters><parameter name="regex">^AnyFunSuite[A-Za-z]*$</parameter></parameters>
     <customMessage>Tests must extend org.apache.spark.SparkFunSuite instead.</customMessage>
   </check>
 

--- a/src/main/scala/org/apache/spark/sql/kinesis/KinesisWriteTask.scala
+++ b/src/main/scala/org/apache/spark/sql/kinesis/KinesisWriteTask.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 import scala.util.Try
 
 import com.amazonaws.services.kinesis.producer.{KinesisProducer, UserRecordResult}
-import com.google.common.util.concurrent.{FutureCallback, Futures}
+import com.google.common.util.concurrent.{FutureCallback, Futures, MoreExecutors}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
@@ -76,7 +76,7 @@ private[kinesis] class KinesisWriteTask(producerConfiguration: Map[String, Strin
         sentSeqNumbers = result.getSequenceNumber
       }
     }
-    Futures.addCallback(future, kinesisCallBack)
+    Futures.addCallback(future, kinesisCallBack, MoreExecutors.directExecutor())
 
     sentSeqNumbers
   }

--- a/src/test/scala/org/apache/spark/sql/kinesis/KinesisTestUtils.scala
+++ b/src/test/scala/org/apache/spark/sql/kinesis/KinesisTestUtils.scala
@@ -33,7 +33,7 @@ import com.amazonaws.services.dynamodbv2.document.DynamoDB
 import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClient}
 import com.amazonaws.services.kinesis.model._
 import com.amazonaws.services.kinesis.producer.{KinesisProducer => KPLProducer, KinesisProducerConfiguration, UserRecordResult}
-import com.google.common.util.concurrent.{FutureCallback, Futures}
+import com.google.common.util.concurrent.{FutureCallback, Futures, MoreExecutors}
 
 import org.apache.spark.internal.Logging
 
@@ -366,7 +366,7 @@ private[kinesis] class KPLDataGenerator(regionName: String) extends KinesisDataG
           sentSeqNumbers += ((num, seqNumber))
         }
       }
-      Futures.addCallback(future, kinesisCallBack)
+      Futures.addCallback(future, kinesisCallBack, MoreExecutors.directExecutor())
     }
     producer.flushSync()
     shardIdToSeqNumbers.toMap


### PR DESCRIPTION
This fixes several issues against qubole/kinesis-sql which have been reported but not fixed.  This is a last attempt to get qubole/kinesis-sql working correctly with Spark 3.2.1 (the latest Spark version available on Amazon Elastic MapReduce) before publishing my own jar kinesis-spark-connector jar file from here: https://github.com/roncemer/kinesis-spark-connector.  If this PR isn't merged into qubole/kinesis-sql and a new kinesis-sql jar file published with these changes, within a short time, I will have no choice but to assume that qubole/kinesis-sql is no longer maintained (for two years and counting now), and post messages wherever qubole/kinesis-sql is mentioned directing users to https://github.com/roncemer/kinesis-spark-connector, and requesting help maintaining new releases in a timely fashion whenever a new Spark version is released.