### PR TITLE
Upgrade jackson-dataformat-cbor to version 2.14.3 and fix vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <sbt.project.name>sql-kinesis</sbt.project.name>
     <spark.version>2.4.0</spark.version>
     <scala.binary.version>2.11</scala.binary.version>
-    <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.14.3</fasterxml.jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>


### PR DESCRIPTION
According to the link below, a security vulnerability was found in the jackson-dataformat-cbor library.
The library currently using in project is version 2.6.7 and is too low.

Thus, the Jackson version specified in pom.xml was upgraded.

[https://security.snyk.io/package/maven/com.fasterxml.jackson.dataformat:jackson-dataformat-cbor](https://security.snyk.io/package/maven/com.fasterxml.jackson.dataformat:jackson-dataformat-cbor)